### PR TITLE
Use tailwind and css vars to toggle input and button themes dynamically

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import generateSchema from "generate-schema"
 import TailwindForm from "@/components/rjsf"
 import { SiteHeader } from "@/components/site-header"
 import { ThemeProvider } from "@/components/theme-provider"
 import validator from "@rjsf/validator-ajv8"
+import generateSchema from "generate-schema"
 import { useRoutes } from "react-router-dom"
+import { FormStyleProvider, useFormStyle } from "./components/form-style-provider"
+import { FormStyleToggle } from "./components/form-style-toggle"
 import JsonEditor from "./components/json-editor"
 import Samples from "./components/samples"
 import { TailwindIndicator } from "./components/tailwind-indicator"
@@ -44,6 +46,8 @@ function Home() {
     updateUiSchema,
     updateFormData,
   } = useStore(selector)
+
+  const { formStyle } = useFormStyle()
 
   const handleSchemaChange = (value: string) => {
     try {
@@ -206,10 +210,10 @@ function Home() {
               </div>
             </div>
             <div className="col-span-2 grid items-start gap-6 lg:col-span-1">
-              <ResponsiveContainer heading="Tailwind Form">
+              <ResponsiveContainer heading="Tailwind Form" actions={<FormStyleToggle />}>
                 <div className="flex flex-col">
                   <div
-                    className="border"
+                    className={`border ${formStyle}`}
                     style={{
                       padding: 20,
                     }}
@@ -240,11 +244,13 @@ function App() {
 
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <div className="relative flex min-h-screen flex-col">
-        <SiteHeader />
-        <div className="flex-1">{children}</div>
-      </div>
-      <TailwindIndicator />
+      <FormStyleProvider>
+        <div className="relative flex min-h-screen flex-col">
+          <SiteHeader />
+          <div className="flex-1">{children}</div>
+        </div>
+        <TailwindIndicator />
+      </FormStyleProvider>
     </ThemeProvider>
   )
 }

--- a/src/components/form-style-provider.tsx
+++ b/src/components/form-style-provider.tsx
@@ -1,0 +1,56 @@
+// src/components/form-style-provider.tsx
+import { createContext, useContext, useState } from "react"
+
+type FormStyle = "default" | "indigo-rounded"
+
+type FormStyleProviderProps = {
+  children: React.ReactNode
+  defaultStyle?: FormStyle
+  storageKey?: string
+}
+
+type FormStyleProviderState = {
+  formStyle: FormStyle
+  setFormStyle: (style: FormStyle) => void
+}
+
+const initialState: FormStyleProviderState = {
+  formStyle: "default",
+  setFormStyle: () => null,
+}
+
+const FormStyleContext = createContext<FormStyleProviderState>(initialState)
+
+export function FormStyleProvider({
+                                    children,
+                                    defaultStyle = "default",
+                                    storageKey = "form-style",
+                                    ...props
+                                  }: FormStyleProviderProps) {
+  const [formStyle, setFormStyle] = useState<FormStyle>(
+    () => (localStorage.getItem(storageKey) as FormStyle) || defaultStyle
+  )
+
+  const value = {
+    formStyle,
+    setFormStyle: (style: FormStyle) => {
+      localStorage.setItem(storageKey, style)
+      setFormStyle(style)
+    },
+  }
+
+  return (
+    <FormStyleContext.Provider {...props} value={value}>
+      {children}
+    </FormStyleContext.Provider>
+  )
+}
+
+export const useFormStyle = () => {
+  const context = useContext(FormStyleContext)
+
+  if (context === undefined)
+    throw new Error("useFormStyle must be used within a FormStyleProvider")
+
+  return context
+}

--- a/src/components/form-style-toggle.tsx
+++ b/src/components/form-style-toggle.tsx
@@ -1,0 +1,15 @@
+// src/components/form-style-toggle.tsx
+import { useFormStyle } from "./form-style-provider"
+
+export function FormStyleToggle() {
+  const { formStyle, setFormStyle } = useFormStyle()
+
+  return (
+    <button
+      onClick={() => setFormStyle(formStyle === "default" ? "indigo-rounded" : "default")}
+      className="rounded bg-primary/90 px-3 py-1 text-sm text-primary-foreground hover:bg-primary"
+    >
+      {formStyle === "default" ? "Set to Indigo Rounded" : "Set to Default Style"}
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -57,3 +57,25 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  /* Define indigo-rounded overrides via custom variables */
+  .indigo-rounded {
+    /* 79,70,229 corresponds to Tailwind\'s indigo-500 */
+    --form-border: 79, 70, 229;
+    --form-ring: 79, 70, 229;
+    --radius: .5rem;
+    --background-color: 79, 70, 229;
+  }
+  .indigo-rounded button {
+    border-radius: var(--radius);
+    background-color: rgb(var(--background-color));
+    border: none;
+    transition: background-color 0.3s, box-shadow 0.3s;
+  }
+
+  .indigo-rounded button:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgb(var(--form-ring) / 0.5);
+  }
+}


### PR DESCRIPTION
Enhance form theming by introducing a Form Theme Provider. This update enables toggling between default and indigo-rounded form styles, allowing for experimentation with different form treatments including custom rounded corners and focus states.

```css
  /* Define indigo-rounded overrides via custom variables */
  .indigo-rounded {
    /* 79,70,229 corresponds to Tailwind\'s indigo-500 */
    --form-border: 79, 70, 229;
    --form-ring: 79, 70, 229;
    --radius: .5rem;
    --background-color: 79, 70, 229;
  }
```